### PR TITLE
Use exchangerates api for multiple currencies

### DIFF
--- a/App/repositories/finances.ts
+++ b/App/repositories/finances.ts
@@ -1,6 +1,8 @@
 import { instance } from '../resources/axios'
 
 
+//v5kKCWJpl7UpT9NJmczFekgJA5H88LQO
+
 const DOLLAR_URL = 'https://totoro.banrep.gov.co/estadisticas-economicas/rest/consultaDatosService/consultaMercadoCambiario'
 
 type FinancialResponse = [ [string, string] ]
@@ -12,5 +14,19 @@ export const fetchUSDtoCOPConv = async() => {
 		return response.data
 	} catch(error) {
 		console.log('Error getting dollar url:', error)
+	}
+}
+
+const exchangeRatesBaseURL = 'https://api.apilayer.com/exchangerates_data'
+
+export const getLatest = async (base, currencies) => {
+	try {
+		const response = await instance.get(`${exchangeRatesBaseURL}/latest?symbols=${currencies.join(',')}&base=${base}`)
+		if(response) {
+			return response.data
+		}
+		return {}
+	} catch(error) {
+		console.log('Error getting latest rates', error)
 	}
 }

--- a/App/resources/axios.ts
+++ b/App/resources/axios.ts
@@ -10,4 +10,4 @@ const httpsAgent = new https.Agent({
 	secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
 })
 
-export const instance = axios.create({ httpsAgent })
+export const instance = axios.create({ httpsAgent, headers: { 'apikey': 'v5kKCWJpl7UpT9NJmczFekgJA5H88LQO' } })

--- a/App/services/finances.ts
+++ b/App/services/finances.ts
@@ -1,4 +1,7 @@
-import { fetchUSDtoCOPConv } from '../repositories/finances'
+import { fetchUSDtoCOPConv, getLatest } from '../repositories/finances'
+
+const currencies = ['COP', 'MXN']
+const base = 'USD'
 
 export const getFinancialInfo = async() => {
 	const financeInfo = await calculateFinanceInfo()
@@ -7,16 +10,10 @@ export const getFinancialInfo = async() => {
 	}
 }
 
-const buildMessage = ({ current }) => {
-	return `TRM USD->COP *${current.toFixed(2)}*`
+const buildMessage = ({ base, rates }) => {
+	return Object.keys(rates).map(symbol => `TRM ${base}->${symbol} *${rates[symbol]}*`).join('\n')
 }
 
 const calculateFinanceInfo = async() => {
-	const data = await fetchUSDtoCOPConv()
-	if(data) {
-		const avg = data.reduce((acc, curr) => acc + parseFloat(curr[1]), 0) / data.length
-		const current = parseFloat(data[data.length - 1][1])
-
-		return { avg, current }
-	}
+	return await getLatest(base, currencies)
 }


### PR DESCRIPTION
Support for multiple currencies using external exchange api
Dummy api key added with 250 requests per month free

Locally tested only with the message object, needs intregration tests validation to make sure the message is well formed when showed as a whatsapp message 

```
{ text: 'Bot: TRM USD->COP *4563.54*\nTRM USD->MXN *17.78003*' }
```